### PR TITLE
`quasar dev` failing inside electron directory

### DIFF
--- a/template/config/index.js
+++ b/template/config/index.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'production') {
     name: config.name,
 
     // Electron version
-    version: require('../node_modules/electron-prebuilt/package.json').version,
+    electronVersion: require('../node_modules/electron/package.json').version,
     arch: 'x64',
     asar: true,
     dir: path.join(__dirname, '../../dist'),

--- a/template/package.json
+++ b/template/package.json
@@ -13,12 +13,9 @@
     "colors": "^1.1.2",
     "cross-env": "^3.1.3",
     "devtron": "^1.4.0",
+    "electron": "^1.5.0",
     "electron-devtools-installer": "^2.0.1",
     "electron-packager": "^8.2.0",
     "shelljs": "^0.7.5"
-  },
-  "dependencies": {
-    "electron": "^1.4.5",
-    "electron-prebuilt": "^1.4.5"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "description": "Quasar App wrapped with Electron",
   "main": "electron.js",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development node_modules/electron/dist/electron electron.js",
+    "dev": "cross-env NODE_ENV=development electron electron.js",
     "clean": "node build/script.clean.js",
     "build": "node build/script.build.js"
   },


### PR DESCRIPTION
Solution to [this](https://github.com/quasarframework/electron-wrapper/issues/1) issue.

The `dev` script is referencing electron from `node_modules/electron/dist/electron electron.js` which is not available with recent release of electron.

Also, we don't need `electron-prebuilt` anymore. It can be replaced with just `electron`.

The build config is also updated to keep up with recent changes on webpack.